### PR TITLE
Enhance JobHuntAgent for Google Sheets email automation

### DIFF
--- a/req.txt
+++ b/req.txt
@@ -6,3 +6,5 @@ chromadb
 fastapi
 uvicorn
 python-multipart
+gspread
+google-auth

--- a/src/agents/job_hunt.py
+++ b/src/agents/job_hunt.py
@@ -1,0 +1,100 @@
+"""Agent for sending job application emails from Google Sheets.
+
+The agent fetches contacts from a sheet, chooses a template based on the
+vacancy type, formats the template with row values and dispatches the email.
+Rows that already contain ``Sent`` in the status column are skipped and marked
+once an email is successfully delivered.
+"""
+from typing import Dict, Tuple, Optional
+import smtplib
+from email.mime.text import MIMEText
+
+
+class JobHuntAgent:
+    """Reads a sheet and emails contacts based on vacancy type."""
+
+    def __init__(
+        self,
+        creds_file: str,
+        sheet_key: str,
+        smtp_server: str,
+        smtp_port: int,
+        smtp_user: str,
+        smtp_password: str,
+        sheet: Optional[object] = None,
+    ) -> None:
+        scopes = [
+            "https://www.googleapis.com/auth/spreadsheets.readonly",
+            "https://www.googleapis.com/auth/drive.readonly",
+        ]
+        if sheet is None:
+            import gspread
+            from google.oauth2.service_account import Credentials
+
+            credentials = Credentials.from_service_account_file(creds_file, scopes=scopes)
+            client = gspread.authorize(credentials)
+            sheet = client.open_by_key(sheet_key).sheet1
+        self.sheet = sheet
+        self.smtp_server = smtp_server
+        self.smtp_port = smtp_port
+        self.smtp_user = smtp_user
+        self.smtp_password = smtp_password
+
+    def _send_email(self, recipient: str, subject: str, body: str) -> None:
+        msg = MIMEText(body)
+        msg["Subject"] = subject
+        msg["From"] = self.smtp_user
+        msg["To"] = recipient
+        with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
+            server.starttls()
+            server.login(self.smtp_user, self.smtp_password)
+            server.sendmail(self.smtp_user, [recipient], msg.as_string())
+
+    def run(
+        self,
+        templates: Dict[str, Tuple[str, str]],
+        email_column: str = "Email",
+        type_column: str = "Type",
+        status_column: str = "Status",
+    ) -> int:
+        """Reads contacts and sends emails using templates.
+
+        Args:
+            templates: Map of vacancy type to ``(subject, body)`` templates.
+            email_column: Column name containing email addresses.
+            type_column: Column describing the vacancy type.
+            status_column: Column used to mark already-contacted rows.
+
+        Returns:
+            Number of successfully dispatched emails.
+        """
+
+        header = [h.lower() for h in self.sheet.row_values(1)]
+        try:
+            email_idx = header.index(email_column.lower())
+            type_idx = header.index(type_column.lower())
+        except ValueError as exc:  # pragma: no cover - defensive programming
+            raise ValueError("Required column missing") from exc
+
+        status_idx = header.index(status_column.lower()) if status_column.lower() in header else None
+
+        rows = self.sheet.get_all_records()
+        sent = 0
+        for row_num, row in enumerate(rows, start=2):
+            lowered = {k.lower(): v for k, v in row.items()}
+            email = lowered.get(email_column.lower())
+            job_type = lowered.get(type_column.lower())
+            status = lowered.get(status_column.lower()) if status_idx is not None else None
+            if not email or not job_type or (status and str(status).strip().lower() == "sent"):
+                continue
+            key = str(job_type).strip().lower()
+            subject_tpl, body_tpl = templates.get(
+                key, templates.get("default", ("Job Application", ""))
+            )
+            subject = subject_tpl.format(**row)
+            body = body_tpl.format(**row)
+            self._send_email(email, subject, body)
+            sent += 1
+            if status_idx is not None:
+                self.sheet.update_cell(row_num, status_idx + 1, "Sent")
+        return sent

--- a/src/job_hunt_runner.py
+++ b/src/job_hunt_runner.py
@@ -1,0 +1,28 @@
+"""CLI for running the JobHuntAgent end-to-end.
+
+The script expects environment variables with credentials for Google Sheets
+and SMTP. A very small set of templates is included for demonstration purposes.
+"""
+import os
+from agents.job_hunt import JobHuntAgent
+
+TEMPLATES = {
+    "software": ("Application for Software Role", "Hello {Name},\nI am applying for the software position."),
+    "default": ("Job Application", "Hello {Name},\nPlease consider my application."),
+}
+
+def main() -> None:
+    agent = JobHuntAgent(
+        os.environ["GOOGLE_CREDS_FILE"],
+        os.environ["SHEET_KEY"],
+        os.environ["SMTP_SERVER"],
+        int(os.environ.get("SMTP_PORT", 587)),
+        os.environ["SMTP_USER"],
+        os.environ["SMTP_PASSWORD"],
+    )
+    sent = agent.run(TEMPLATES)
+    print(f"Sent {sent} emails.")
+
+
+if __name__ == "__main__":  # pragma: no cover - simple script
+    main()

--- a/tests/test_job_hunt.py
+++ b/tests/test_job_hunt.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+import pytest
+
+from agents.job_hunt import JobHuntAgent
+
+
+class DummySheet:
+    def __init__(self, header, records):
+        self.header = header
+        # normalize records to include all headers, ignoring case
+        self._records = [
+            {h: r.get(h, r.get(h.lower(), "")) for h in header} for r in records
+        ]
+
+    def get_all_records(self):
+        return self._records
+
+    def row_values(self, row):
+        if row == 1:
+            return self.header
+        return [self._records[row - 2].get(h, "") for h in self.header]
+
+    def update_cell(self, row, col, value):
+        self._records[row - 2][self.header[col - 1]] = value
+
+
+def _agent_for(sheet):
+    return JobHuntAgent(
+        "creds.json",
+        "sheet-key",
+        "smtp.example.com",
+        587,
+        "user",
+        "pass",
+        sheet=sheet,
+    )
+
+
+def test_run_sends_emails_and_marks_status():
+    sheet = DummySheet(
+        ["Email", "Type", "Status", "Name"],
+        [
+            {"Email": "alice@example.com", "Type": "Software", "Name": "Alice"},
+            {"email": "bob@example.com", "type": "default", "Name": "Bob"},
+        ],
+    )
+    agent = _agent_for(sheet)
+    agent._send_email = Mock()
+    templates = {
+        "software": ("Subject1 {Name}", "Body1 for {Name}"),
+        "default": ("Subject2 {Name}", "Body2 for {Name}"),
+    }
+    sent = agent.run(templates)
+    assert sent == 2
+    agent._send_email.assert_any_call(
+        "alice@example.com", "Subject1 Alice", "Body1 for Alice"
+    )
+    agent._send_email.assert_any_call(
+        "bob@example.com", "Subject2 Bob", "Body2 for Bob"
+    )
+    assert sheet.get_all_records()[0]["Status"] == "Sent"
+    assert sheet.get_all_records()[1]["Status"] == "Sent"
+
+
+def test_skips_rows_with_sent_status():
+    sheet = DummySheet(
+        ["Email", "Type", "Status"],
+        [
+            {"Email": "charlie@example.com", "Type": "Software", "Status": "Sent"},
+            {"Email": "dave@example.com", "Type": "Software", "Status": ""},
+        ],
+    )
+    agent = _agent_for(sheet)
+    agent._send_email = Mock()
+    templates = {"software": ("S", "B")}
+    sent = agent.run(templates)
+    assert sent == 1
+    agent._send_email.assert_called_once_with("dave@example.com", "S", "B")
+
+
+def test_missing_columns_raise():
+    sheet = DummySheet(["Email"], [{"Email": "eve@example.com"}])
+    agent = _agent_for(sheet)
+    with pytest.raises(ValueError):
+        agent.run({})


### PR DESCRIPTION
## Summary
- mark dispatched rows and support templated emails in `JobHuntAgent`
- add CLI runner for end-to-end job hunt automation
- expand test suite to cover status updates, skipping sent rows, and missing headers

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d8622bc833388c0676e7a6d2098