### PR TITLE
Add search workflow similar to Perplexity

### DIFF
--- a/perplexity/__init__.py
+++ b/perplexity/__init__.py
@@ -1,0 +1,1 @@
+from .app import app

--- a/perplexity/app.py
+++ b/perplexity/app.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from .graph import create_graph
+
+app = FastAPI()
+workflow = create_graph()
+
+@app.get("/query")
+async def query(q: str):
+    result = workflow.invoke({"question": q})
+    return {"answer": result.get("answer"), "sources": result.get("sources")}

--- a/perplexity/graph.py
+++ b/perplexity/graph.py
@@ -1,0 +1,19 @@
+from langgraph.graph import StateGraph, END
+from .search import google_search
+from .summarizer import Summarizer
+
+def create_graph(model: str = "gpt-3.5-turbo"):
+    summarizer = Summarizer(model)
+    def search_node(state: dict):
+        state["sources"] = google_search(state["question"])
+        return state
+    def answer_node(state: dict):
+        state["answer"] = summarizer.run(state["question"], state["sources"])
+        return state
+    graph = StateGraph(dict)
+    graph.add_node("search", search_node)
+    graph.add_node("answer", answer_node)
+    graph.add_edge("search", "answer")
+    graph.add_edge("answer", END)
+    graph.set_entry_point("search")
+    return graph.compile()

--- a/perplexity/search.py
+++ b/perplexity/search.py
@@ -1,0 +1,17 @@
+import requests
+from bs4 import BeautifulSoup
+
+def google_search(query: str, num: int = 5):
+    resp = requests.get("https://www.google.com/search", params={"q": query, "num": num}, headers={"User-Agent": "Mozilla/5.0"})
+    soup = BeautifulSoup(resp.text, "html.parser")
+    out = []
+    for g in soup.select("div.g"):
+        a = g.find("a")
+        t = g.find("h3")
+        if not a or not t:
+            continue
+        s = g.find("span", class_="aCOpRe")
+        out.append({"title": t.text, "link": a["href"], "snippet": s.text if s else ""})
+        if len(out) >= num:
+            break
+    return out

--- a/perplexity/summarizer.py
+++ b/perplexity/summarizer.py
@@ -1,0 +1,9 @@
+from langchain_openai import ChatOpenAI
+
+class Summarizer:
+    def __init__(self, model: str = "gpt-3.5-turbo"):
+        self.llm = ChatOpenAI(model=model)
+    def run(self, question: str, sources):
+        lines = [f"{i+1}. {s['title']} {s['link']} {s['snippet']}" for i, s in enumerate(sources)]
+        prompt = question + "\n" + "\n".join(lines) + "\nAnswer with citations"
+        return self.llm.invoke(prompt).content

--- a/req.txt
+++ b/req.txt
@@ -8,3 +8,5 @@ uvicorn
 python-multipart
 gspread
 google-auth
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add new `perplexity` workflow for Google-like search with LLM summarization
- expose FastAPI endpoint for querying and returning cited sources
- declare `requests` and `beautifulsoup4` dependencies

## Testing
- `PYTHONPATH=src pytest tests/test_job_hunt.py`
- `pip install requests beautifulsoup4` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae83760e1083339256e378ba7838bf